### PR TITLE
add napari dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ipykernel>=5.2.0
 IPython>=7.7.0
+napari>=0.4.4
 napari-plugin-engine>=0.1.9
 qtconsole>=4.5.1,!=4.7.6
 qtpy>=1.7.0


### PR DESCRIPTION
This PR would add a napari dependency, which we need because we need the `get_theme` and `stylesheet` template here https://github.com/napari/napari-console/blob/main/napari_console/qt_console.py#L14

It would be nice if we could find another way to do this at some point, but we need it now, and it might help fix https://github.com/conda-forge/staged-recipes/pull/13773 cc @jni @tlambert03 