### PR TITLE
Set underlying console QTextEdit widget as proxy for QtConsole focus

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -59,17 +59,11 @@ jobs:
         run: pip install tox-conda
 
       - name: Test with tox
-        run: |
-          if [ "$RUNNER_OS" == "Linux" ] ; then
-            Xvfb :99 -screen 0 1024x768x24 & sleep 3
-            herbstluftwm & sleep 1
-            python -m tox -vv
-          else
-            python -m tox -vv
-          fi
-        shell: bash
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: python -m tox -vv
         env:
-          DISPLAY: ":99"
+          WM: herbstluftwm
           PLATFORM: ${{ matrix.platform }}
           PYVISTA_OFF_SCREEN: True
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -43,6 +43,12 @@ jobs:
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
           if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
 
+      # run a minimal wm for linux tests that depend on UI events (e.g. setFocus)
+      # see https://github.com/pytest-dev/pytest-qt/issues/206
+      - name: Install Xfvb and WM on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y xvfb herbstluftwm
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -53,10 +59,18 @@ jobs:
         run: pip install tox-conda
 
       - name: Test with tox
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: python -m tox -vv
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ] ; then
+            /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset
+            sleep 3
+            herbstluftwm & sleep 1
+            python -m tox -vv
+          else
+            python -m tox -vv
+          fi
+        shell: bash
         env:
+          DISPLAY: ":99.0"
           PLATFORM: ${{ matrix.platform }}
           PYVISTA_OFF_SCREEN: True
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -34,7 +34,6 @@ jobs:
             
       - uses: tlambert03/setup-qt-libs@v1
 
-
       # strategy borrowed from vispy for installing opengl libs on windows
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
@@ -45,9 +44,9 @@ jobs:
 
       # run a minimal wm for linux tests that depend on UI events (e.g. setFocus)
       # see https://github.com/pytest-dev/pytest-qt/issues/206
-      - name: Install Xfvb and WM on Linux
+      - name: Install WM on Linux
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y xvfb herbstluftwm
+        run: sudo apt-get update && sudo apt-get install -y herbstluftwm
 
       - name: Install dependencies
         run: |
@@ -63,7 +62,6 @@ jobs:
         with:
           run: python -m tox -vv
         env:
-          WM: herbstluftwm
           PLATFORM: ${{ matrix.platform }}
           PYVISTA_OFF_SCREEN: True
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -61,8 +61,7 @@ jobs:
       - name: Test with tox
         run: |
           if [ "$RUNNER_OS" == "Linux" ] ; then
-            /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset
-            sleep 3
+            Xvfb :99 -screen 0 1024x768x24 & sleep 3
             herbstluftwm & sleep 1
             python -m tox -vv
           else
@@ -70,7 +69,7 @@ jobs:
           fi
         shell: bash
         env:
-          DISPLAY: ":99.0"
+          DISPLAY: ":99"
           PLATFORM: ${{ matrix.platform }}
           PYVISTA_OFF_SCREEN: True
 

--- a/napari_console/_tests/test_qt_console.py
+++ b/napari_console/_tests/test_qt_console.py
@@ -53,9 +53,11 @@ def test_console_focus_proxy(qtbot, make_test_viewer):
     viewer = make_test_viewer()
 
     # setFocus does nothing if the widget is not shown
-    viewer.show()
-    viewer.window._qt_viewer.toggle_console_visibility()
     console = viewer.window._qt_viewer.console
+    # qtbot.addWidget(console)  # causes an error
+    with qtbot.waitExposed(console):
+        viewer.show()
+        viewer.window._qt_viewer.toggle_console_visibility()
 
     console.clearFocus()
 
@@ -72,4 +74,4 @@ def test_console_focus_proxy(qtbot, make_test_viewer):
             console._control.hasFocus()
         ), "underlying QTextEdit widget never received focus"
 
-    qtbot.waitUntil(control_has_focus, timeout=500)
+    qtbot.waitUntil(control_has_focus)

--- a/napari_console/_tests/test_qt_console.py
+++ b/napari_console/_tests/test_qt_console.py
@@ -48,7 +48,7 @@ def test_ipython_console(qtbot, make_test_viewer):
         assert console.kernel_client is None
 
 
-def test_console_focus_proxy(qtbot, make_test_viewer, linux_wm):
+def test_console_focus_proxy(qtbot, make_test_viewer, linux_wm_local):
     """Test setting/clearing focus on a QtConsole sets/clears focus on the underlying QTextEdit"""
     viewer = make_test_viewer()
 

--- a/napari_console/_tests/test_qt_console.py
+++ b/napari_console/_tests/test_qt_console.py
@@ -48,7 +48,7 @@ def test_ipython_console(qtbot, make_test_viewer):
         assert console.kernel_client is None
 
 
-def test_console_focus_proxy(qtbot, make_test_viewer):
+def test_console_focus_proxy(qtbot, make_test_viewer, linux_wm):
     """Test setting/clearing focus on a QtConsole sets/clears focus on the underlying QTextEdit"""
     viewer = make_test_viewer()
 

--- a/napari_console/_tests/test_qt_console.py
+++ b/napari_console/_tests/test_qt_console.py
@@ -46,3 +46,30 @@ def test_ipython_console(qtbot, make_test_viewer):
         console = QtConsole(viewer)
         qtbot.addWidget(console)
         assert console.kernel_client is None
+
+
+def test_console_focus_proxy(qtbot, make_test_viewer):
+    """Test setting/clearing focus on a QtConsole sets/clears focus on the underlying QTextEdit"""
+    viewer = make_test_viewer()
+
+    # setFocus does nothing if the widget is not shown
+    viewer.show()
+    viewer.window._qt_viewer.toggle_console_visibility()
+    console = viewer.window._qt_viewer.console
+
+    console.clearFocus()
+
+    assert (
+        not console._control.hasFocus()
+    ), "underlying QTextEdit widget should not have focus after clearing"
+
+    console.setFocus()
+
+    # assert the console control has focus
+    # timeout (in ms) avoids flaky tests since setting focus takes time
+    def control_has_focus():
+        assert (
+            console._control.hasFocus()
+        ), "underlying QTextEdit widget never received focus"
+
+    qtbot.waitUntil(control_has_focus, timeout=500)

--- a/napari_console/_tests/test_qt_console.py
+++ b/napari_console/_tests/test_qt_console.py
@@ -54,7 +54,6 @@ def test_console_focus_proxy(qtbot, make_test_viewer, linux_wm):
 
     # setFocus does nothing if the widget is not shown
     console = viewer.window._qt_viewer.console
-    # qtbot.addWidget(console)  # causes an error
     with qtbot.waitExposed(console):
         viewer.show()
         viewer.window._qt_viewer.toggle_console_visibility()
@@ -67,7 +66,6 @@ def test_console_focus_proxy(qtbot, make_test_viewer, linux_wm):
 
     console.setFocus()
 
-    # assert the console control has focus
     # timeout (in ms) avoids flaky tests since setting focus takes time
     def control_has_focus():
         assert (

--- a/napari_console/conftest.py
+++ b/napari_console/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 
 @pytest.fixture
-def linux_wm():
+def linux_wm_local():
     """Start a WM in the background for tests that need a WM.
 
     This will only run on Linux and in CI (determined by CI env var).

--- a/napari_console/conftest.py
+++ b/napari_console/conftest.py
@@ -1,0 +1,29 @@
+import os
+import platform
+import subprocess
+import time
+
+import pytest
+
+
+@pytest.fixture
+def linux_wm():
+    """Start a WM in the background for tests that need a WM.
+
+    This will only run on Linux and in CI (determined by CI env var).
+    """
+    wm = os.environ.get("WM", "herbstluftwm")
+    proc = None
+    if platform.system() == "Linux" and os.environ.get("CI"):
+        proc = subprocess.Popen([wm])
+        time.sleep(1)
+
+    yield proc
+
+    if proc:
+        proc.terminate()
+        try:
+            proc.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            raise subprocess.SubprocessError(f"failed to terminate window manager '{wm}'")

--- a/napari_console/qt_console.py
+++ b/napari_console/qt_console.py
@@ -82,6 +82,10 @@ class QtConsole(RichJupyterWidget):
         self.viewer.events.theme.connect(self._update_theme)
         user_variables = {'viewer': self.viewer}
 
+        # this makes calling `setFocus()` on a QtConsole give keyboard focus to
+        # the underlying `QTextEdit` widget
+        self.setFocusProxy(self._control)
+
         # get current running instance or create new instance
         shell = get_ipython()
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ conda_channels =
 deps = 
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
-    pytest-xvfb ; sys_platform == 'linux'
     pyqt: napari[pyqt5,testing]
     pyside: napari[pyside2,testing]
     imageio !=2.22.1  # workaround for https://github.com/imageio/imageio/issues/887

--- a/tox.ini
+++ b/tox.ini
@@ -41,4 +41,5 @@ deps =
     pytest-xvfb ; sys_platform == 'linux'
     pyqt: napari[pyqt5,testing]
     pyside: napari[pyside2,testing]
+    imageio !=2.22.1  # workaround for https://github.com/imageio/imageio/issues/887
 commands = pytest -v --color=yes --cov=napari_console --cov-report=xml


### PR DESCRIPTION
This is meant to be a precursor to fixing https://github.com/napari/napari/issues/5166, allowing napari to programmatically set the keyboard focus on the console.

This is draft for now as I intended to open this in my own fork and need to fix the test failures in CI. Sorry!