### PR TITLE
Disable console if napari launched from jupyter

### DIFF
--- a/napari_console/qt_console.py
+++ b/napari_console/qt_console.py
@@ -115,23 +115,15 @@ class QtConsole(RichJupyterWidget):
             self.kernel_client = kernel_client
             self.shell = kernel_manager.kernel.shell
             self.push = self.shell.push
-        elif isinstance(shell, TerminalInteractiveShell):
-            # if launching from an ipython terminal then adding a console is
-            # not supported. Instead users should use the ipython terminal for
-            # the same functionality.
+        elif isinstance(shell, (TerminalInteractiveShell, ZMQInteractiveShell)):
+            # if launching from an ipython or jupyter then adding a console is
+            # not supported. Instead users should use the existing interactive 
+            # terminal for the same functionality.
             self.kernel_client = None
             self.kernel_manager = None
             self.shell = None
             self.push = lambda var: None
 
-        elif isinstance(shell, ZMQInteractiveShell):
-            # if launching from jupyter notebook, then adding a console is
-            # not supported. Instead users should continue to use jupyter for
-            # the same functionality.
-            self.kernel_client = None
-            self.kernel_manager = None
-            self.shell = None
-            self.push = lambda var: None
         else:
             raise ValueError(
                 'ipython shell not recognized; ' f'got {type(shell)}'

--- a/napari_console/qt_console.py
+++ b/napari_console/qt_console.py
@@ -125,18 +125,13 @@ class QtConsole(RichJupyterWidget):
             self.push = lambda var: None
 
         elif isinstance(shell, ZMQInteractiveShell):
-            # if launching from jupyter notebook, connect to the existing
-            # kernel
-            kernel_client = QtKernelClient(
-                connection_file=get_connection_file()
-            )
-            kernel_client.load_connection_file()
-            kernel_client.start_channels()
-
+            # if launching from jupyter notebook, then adding a console is
+            # not supported. Instead users should continue to use jupyter for
+            # the same functionality.
+            self.kernel_client = None
             self.kernel_manager = None
-            self.kernel_client = kernel_client
-            self.shell = shell
-            self.push = self.shell.push
+            self.shell = None
+            self.push = lambda var: None
         else:
             raise ValueError(
                 'ipython shell not recognized; ' f'got {type(shell)}'


### PR DESCRIPTION
See: https://github.com/napari/napari/pull/5213#issuecomment-1304093902
And: https://github.com/napari/docs/pull/53

The console button is now disabled when napari is launched from jupyter, because the console was blank then anyways. 
This PR aims to clean up the loose ends.
CC: @andy-sweet 