### PR TITLE
Migrate to npe2

### DIFF
--- a/napari_console/_hookimpl.py
+++ b/napari_console/_hookimpl.py
@@ -1,4 +1,3 @@
-from napari_plugin_engine import napari_hook_implementation
 from .qt_console import QtConsole
 
 # Wait to use hook impl

--- a/napari_console/napari.yaml
+++ b/napari_console/napari.yaml
@@ -1,0 +1,2 @@
+name: napari-console
+schema_version: 0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "setuptools >= 42",
   "wheel",
-  "setuptools_scm>=3.4"
+  "setuptools_scm>=8.0"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = napari_console
+name = napari-console
 description = A plugin that adds a console to napari
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,48 +1,44 @@
 [metadata]
-name = napari-console
-url = https://github.com/napari/napari-console
-license = BSD 3-Clause
-license_file = LICENSE
+name = napari_console
 description = A plugin that adds a console to napari
 long_description = file: README.md
 long_description_content_type = text/markdown
+url = https://github.com/napari/napari-console
 author = Nicholas Sofroniew
 author_email = sofroniewn@gmail.com
+license = BSD-3-Clause
+license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta
-    Intended Audience :: Developers
     Framework :: napari
-    Topic :: Software Development :: Testing
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    Operating System :: OS Independent
-    License :: OSI Approved :: BSD License
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Topic :: Software Development :: Testing
 
 [options]
-zip_safe = False
 packages = find:
+install_requires =
+    IPython>=7.7.0
+    ipykernel>=5.2.0
+    napari-plugin-engine>=0.1.9
+    qtconsole!=4.7.6,!=5.4.2,>=4.5.1
+    qtpy>=1.7.0
 python_requires = >=3.8
 include_package_data = True
-install_requires =
-    ipykernel>=5.2.0
-    IPython>=7.7.0
-    napari-plugin-engine>=0.1.9
-    qtconsole>=4.5.1,!=4.7.6,!=5.4.2
-    qtpy>=1.7.0
-
-[options.package_data]
-* = *.pyi
-napari_builtins =
-    builtins.yaml
-
-# for explanation of %(extra)s syntax see:
-# https://github.com/pypa/setuptools/issues/1260#issuecomment-438187625
-# this syntax may change in the future
+zip_safe = False
 
 [options.entry_points]
-napari.plugin =
-   console = napari_console 
+napari.manifest =
+    napari-console = napari_console:napari.yaml
+
+[options.package_data]
+napari_console = napari.yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ packages = find:
 install_requires =
     IPython>=7.7.0
     ipykernel>=5.2.0
-    napari-plugin-engine>=0.1.9
     qtconsole!=4.7.6,!=5.4.2,>=4.5.1
     qtpy>=1.7.0
 python_requires = >=3.8


### PR DESCRIPTION
This migrate napari-console to npe2. It silences 
```
0.01s - Debugger warning: It seems that frozen modules are being used, which may
0.00s - make the debugger miss breakpoints. Please pass -Xfrozen_modules=off
0.00s - to python to disable frozen modules.
0.00s - Note: Debugging will proceed. Set PYDEVD_DISABLE_FILE_VALIDATION=1 to disable this validation.
```
warning on napari startup 

closes napari/napari#6286