### PR TITLE
Update aganders/headless-gui@v2 (silence nodejs warnings on github actions)

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -54,7 +54,7 @@ jobs:
         run: pip install tox-conda tox-gh-actions
 
       - name: Test with tox
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@v2
         with:
           run: python -m tox -vv
         env:


### PR DESCRIPTION
Reference: https://github.com/aganders3/headless-gui/issues/10

When the github actions CI tests run, we see this nodejs warning:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: aganders3/headless-gui@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

This has been fixed by https://github.com/aganders3/headless-gui/pull/11
The fix is available for versions `aganders3/headless-gui@v2.2` and above.