### PR TITLE
Start kernel client channels when reusing already running in-process kernel

### DIFF
--- a/napari_console/qt_console.py
+++ b/napari_console/qt_console.py
@@ -129,10 +129,11 @@ class QtConsole(RichJupyterWidget):
         elif type(shell) == InProcessInteractiveShell:
             # If there is an existing running InProcessInteractiveShell
             # it is likely because multiple viewers have been launched from
-            # the same process. In that case create a new kernel.
-            # Connect existing kernel
+            # the same process. In that case create a new kernel manager but
+            # connect to the existing kernel.
             kernel_manager = QtInProcessKernelManager(kernel=shell.kernel)
             kernel_client = kernel_manager.client()
+            kernel_client.start_channels()
 
             self.kernel_manager = kernel_manager
             self.kernel_client = kernel_client


### PR DESCRIPTION
Closes napari/napari#7413

This PR allows multiple napari viewers in the same session to each have a console, with the consoles having linked histories and kernel (active variables).