### PR TITLE
Add numbered viewer variables to be able to access multiple created viewers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ target/
 
 # pycharm stuff
 .idea/
+
+# spyder project config
+.spyproject/

--- a/napari_console/qt_console.py
+++ b/napari_console/qt_console.py
@@ -89,6 +89,7 @@ class QtConsole(RichJupyterWidget):
     """
 
     min_depth: Optional[int]
+    viewer_number: int = 0
 
     def __init__(self, viewer: 'napari.viewer.Viewer', *, min_depth: int = 1, style_sheet: str = ''):
         super().__init__()
@@ -115,6 +116,7 @@ class QtConsole(RichJupyterWidget):
         if shell is None:
             # If there is no currently running instance create an in-process
             # kernel.
+            user_variables.update({f'viewer{self.viewer_number}': self.viewer})
             kernel_manager = QtInProcessKernelManager()
             kernel_manager.start_kernel(show_banner=False)
             kernel_manager.kernel.gui = 'qt'
@@ -131,6 +133,8 @@ class QtConsole(RichJupyterWidget):
             # it is likely because multiple viewers have been launched from
             # the same process. In that case create a new kernel manager but
             # connect to the existing kernel.
+            self.viewer_number += 1
+            user_variables.update({f'viewer{self.viewer_number}': self.viewer})
             kernel_manager = QtInProcessKernelManager(kernel=shell.kernel)
             kernel_client = kernel_manager.client()
             kernel_client.start_channels()


### PR DESCRIPTION
Closes #40

Enable to access all the available viewers by adding a `viewer{number}` variables as needed. For example, if you create from a single script to viewers you will be able to access/interact with both: one via a `viewer0` variable and the other one via `viewer1`. A preview:

![multiconsole_support_vars](https://github.com/user-attachments/assets/bf01dab7-13a6-4522-9aba-d803135a3691)

### Notes

* One thing that this implementation is not covering is to remove the variable referencing the viewer once the viewer is closed/deleted. So, with this implementation, you will be able to access the deleted viewer from another viewer/napari mainwindow instance and then getting an error when trying to do any operation with the closed/deleted viewer variable. Tried setting some clean up logic at the console `closeEvent` using either `self.push` (setting the respective numbered viewer variable to be something like `None`) or calling the shell `reset_selective` and `drop_by_id` methods but none of those calls helped as far as I was able to check 🤔 Any ideas to handle this are appreciated!