### PR TITLE
Update viewer variable when changing focused console (multiple consoles sharing the same kernel)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ target/
 
 # pycharm stuff
 .idea/
+
+# spyder project config
+.spyproject


### PR DESCRIPTION
Closes #40
Closes #41 (supersedes)

Follow up of the idea at https://github.com/napari/napari-console/issues/40#issuecomment-2525322961

A preview:

![console_viewer_reference_update](https://github.com/user-attachments/assets/45fcd9af-80c7-490c-b803-467934712fd6)

