### PR TITLE
Fix frame capture when using PyQt6

### DIFF
--- a/napari_console/qt_console.py
+++ b/napari_console/qt_console.py
@@ -19,7 +19,7 @@ from qtpy.QtGui import QColor
 from napari.utils.naming import CallerFrame
 
 
-_PREF_LIST = ["napari.", "napari_console.", "in_n_out."]
+_PREF_LIST = ["napari.", "napari_console.", "in_n_out.", "qtpy."]
 
 
 def str_to_rgb(arg):


### PR DESCRIPTION
See https://github.com/napari/napari-console/issues/40#issuecomment-2533216712, https://github.com/napari/napari-console/pull/42#issuecomment-2542733251

These failures were caused by an intervening frame in QtPy when using the Qt6 backend, because QtPy replaced some removed functions in the Qt5->Qt6 transition with their own implementations:

https://github.com/spyder-ide/qtpy/blob/1d2a1eae43bda2a3d0efef605cafc5462389ec03/qtpy/QtWidgets.py#L69-L105

Therefore, when looking for "first frame in the call stack that is not in napari", the frame capture code would stop in QtPy. By adding QtPy to the list of ignored prefixes, this PR fixes the issue in the Qt6 case.