### PR TITLE
pin ipykernel <7.0, bump to python >=3.10 and napari >=0.6

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.13"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -48,7 +48,7 @@ jobs:
           pip install setuptools tox tox-gh-actions
 
       - name: Install tox-conda
-        if: runner.os == 'macOS' && matrix.python-version == '3.9'
+        if: runner.os == 'macOS' && matrix.python-version == '3.10'
         #  we are explicit about tox-gh-action or pip resolver will downgrade
         #  tox, which will be incompatible with tox-gh-action
         run: pip install tox-conda tox-gh-actions

--- a/napari_console/qt_console.py
+++ b/napari_console/qt_console.py
@@ -97,12 +97,6 @@ class QtConsole(RichJupyterWidget):
 
         self.min_depth = min_depth
 
-        # Connect theme update
-        if not style_sheet:
-            # napari <0.5.5 relies on viewer theme event to update the style
-            # (without passing a style value when creating a console)
-            self.viewer.events.theme.connect(self._update_theme)
-
         user_variables = {'viewer': self.viewer}
 
         # this makes calling `setFocus()` on a QtConsole give keyboard focus to
@@ -195,26 +189,9 @@ class QtConsole(RichJupyterWidget):
         # qtconsole unfortunately won't inherit the parent stylesheet
         # so it needs to be directly set when required.
         if style_sheet:
-            # napari >=0.5.5 uses the `style_sheet` kwarg and the `to_rgb_dict` theme method
-            theme = get_theme(self.viewer.theme).to_rgb_dict()
             self.style_sheet = style_sheet
-        else:
-            # napari 0.4.x and <0.5.5 doesn't use the `style_sheet` kwarg and uses the deprecated
-            # `as_dict` kwarg for the `get_theme` function call
-            from napari.qt import get_stylesheet
-            from napari.utils.theme import template
 
-            theme = get_theme(self.viewer.theme, as_dict=True)
-            raw_stylesheet = get_stylesheet()
-            # get template and apply the primary stylesheet
-            # (should probably be done by napari)
-            # After napari 0.4.11, themes are evented models rather than
-            # dicts.
-            self.style_sheet = template(raw_stylesheet, **theme)
-
-            # After napari 0.4.6 the following syntax will be allowed
-            # self.style_sheet = get_stylesheet(self.viewer.theme)
-
+        theme = get_theme(self.viewer.theme).to_rgb_dict()
         # Set syntax styling and highlighting using theme
         self.syntax_style = theme['syntax_style']
         bracket_color = QColor(*str_to_rgb(theme['highlight']))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,14 +26,14 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Testing",
 ]
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "IPython>=7.7.0",
   "ipykernel>=5.2.0,<7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9"
 dependencies = [
   "IPython>=7.7.0",
-  "ipykernel>=5.2.0",
+  "ipykernel>=5.2.0,<0.7",
   "qtconsole!=4.7.6,!=5.4.2,>=4.5.1",
   "qtpy>=1.7.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.9"
 dependencies = [
   "IPython>=7.7.0",
-  "ipykernel>=5.2.0,<0.7",
+  "ipykernel>=5.2.0,<7",
   "qtconsole!=4.7.6,!=5.4.2,>=4.5.1",
   "qtpy>=1.7.0",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py39-{linux,macos,windows}-{pyqt,pyside},py312-{linux,macos,windows}-pyqt
+envlist = py310-{linux,macos,windows}-{pyqt,pyside},py313-{linux,macos,windows}-pyqt
 toxworkdir=/tmp/.tox
 isolated_build = true
 
 [gh-actions]
 python =
-    3.9: py39
-    3.12: py312
+    3.10: py310
+    3.13: py313
     
 [gh-actions:env]
 PLATFORM =
@@ -30,8 +30,8 @@ passenv =
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
 conda_deps =
-    # use conda to install numcodecs on mac py3.9
-    py39-macos: numcodecs
+    # use conda to install numcodecs on mac py3.10
+    py310-macos: numcodecs
 conda_channels =
     conda-forge
 deps = 


### PR DESCRIPTION
This ipykernel release breaks our console. Context:

- https://napari.zulipchat.com/#narrow/channel/212875-general/topic/napari.20and.20Jupyterlab/with/544966638
- https://github.com/napari/napari/pull/7685
- https://github.com/ipython/ipykernel/issues/1438

For now we hard pin until this is figured out.

Also:
- closes https://github.com/napari/napari-console/issues/47
- closes https://github.com/napari/napari-console/issues/46
