### PR TITLE
Add `vispy` and `app-model` to list of frames to omit during scan for variables

### DIFF
--- a/napari_console/qt_console.py
+++ b/napari_console/qt_console.py
@@ -19,7 +19,7 @@ from qtpy.QtGui import QColor
 from napari.utils.naming import CallerFrame
 
 
-_PREF_LIST = ["napari.", "napari_console.", "in_n_out.", "qtpy.", "vispy."]
+_PREF_LIST = ["napari.", "napari_console.", "in_n_out.", "qtpy.", "vispy.", "app_model."]
 
 
 def str_to_rgb(arg):

--- a/napari_console/qt_console.py
+++ b/napari_console/qt_console.py
@@ -19,7 +19,7 @@ from qtpy.QtGui import QColor
 from napari.utils.naming import CallerFrame
 
 
-_PREF_LIST = ["napari.", "napari_console.", "in_n_out.", "qtpy."]
+_PREF_LIST = ["napari.", "napari_console.", "in_n_out.", "qtpy.", "vispy."]
 
 
 def str_to_rgb(arg):


### PR DESCRIPTION
closes #44

As the console shortcut is triggered via vispy, then without vispy in `_PREF_LIST` the console is grabbing vispy variables instead of user script one. 

If it is triggered by the command palette, then there was `app_model` on the frames stack. So also it needs to be added to `_PREF_LIST`