### PR TITLE
Relax codecov ci fail limit to 98% project with 1% threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 98%
+        threshold: 1%


### PR DESCRIPTION
Closes #60.

We should avoid failing PRs on tiny deltas in coverage. This PR still keeps the project coverage at 98%.

To interpret the settings: This configuration tells Codecov to fail a status check if 98% of the codebase is not covered with tests. However, it also allows for a 1% threshold, meaning the true minimum is 97%.