### PR TITLE
Set PYDEVD_DISABLE_FILE_VALIDATION to 1 to prevent the warning

### DIFF
--- a/napari_console/qt_console.py
+++ b/napari_console/qt_console.py
@@ -1,3 +1,6 @@
+import os
+os.environ.setdefault("PYDEVD_DISABLE_FILE_VALIDATION", "1")
+
 import re
 import sys
 import warnings
@@ -135,7 +138,7 @@ class QtConsole(RichJupyterWidget):
             self.push = self.shell.push
         elif isinstance(shell, (TerminalInteractiveShell, ZMQInteractiveShell)):
             # if launching from an ipython or jupyter then adding a console is
-            # not supported. Instead users should use the existing interactive 
+            # not supported. Instead users should use the existing interactive
             # terminal for the same functionality.
             self.kernel_client = None
             self.kernel_manager = None


### PR DESCRIPTION
This PR silences this warning that I get at first launch all the time now -- i think it was introduced in py312?
```
0.00s - Debugger warning: It seems that frozen modules are being used, which may
0.00s - make the debugger miss breakpoints. Please pass -Xfrozen_modules=off
0.00s - to python to disable frozen modules.
0.00s - Note: Debugging will proceed. Set PYDEVD_DISABLE_FILE_VALIDATION=1 to disable this validation.
```

As the warning says, this PR sets the variable to disable the validation.
My understanding is that ipykernel imports debugpy which is why we get this.
My understanding from reading online a bit, is that if you want to debug with breakpoints and things in some of the standrard library you need the `-Xfrozen_modules=off` but people who use debuggers would know this while everyone else doesn't care and the warning is just annoying.
So I think silencing it is fine, because it's basically only actionable by those who are already in the know.